### PR TITLE
Remove Personally Identifiable Information from stripe PaymentIntent metadata and description

### DIFF
--- a/WcaOnRails/app/controllers/registrations_controller.rb
+++ b/WcaOnRails/app/controllers/registrations_controller.rb
@@ -466,10 +466,8 @@ class RegistrationsController < ApplicationController
     stripe_charge = nil
     competition = registration.competition
     registration_metadata = {
-      name: user.name,
-      wca_id: user.wca_id,
-      email: user.email,
       competition: competition.name,
+      registration_url: edit_registration_url(registration),
     }
     begin
       if params[:payment_method_id]
@@ -484,7 +482,7 @@ class RegistrationsController < ApplicationController
           confirmation_method: "manual",
           confirm: true,
           receipt_email: user.email,
-          description: "Registration payment for #{competition.name} by #{registration.user.name}",
+          description: "Registration payment for #{competition.name}",
           metadata: registration_metadata,
         }
         # Log the payment attempt

--- a/WcaOnRails/spec/requests/registrations_spec.rb
+++ b/WcaOnRails/spec/requests/registrations_spec.rb
@@ -526,9 +526,8 @@ RSpec.describe "registrations" do
           charge = Stripe::Charge.retrieve(registration.registration_payments.first.stripe_charge_id, stripe_account: competition.connected_stripe_account_id)
           expect(charge.amount).to eq competition.base_entry_fee.cents
           expect(charge.receipt_email).to eq user.email
-          expect(charge.metadata.wca_id).to eq user.wca_id
-          expect(charge.metadata.email).to eq user.email
           expect(charge.metadata.competition).to eq competition.name
+          expect(charge.metadata.registration_url).to eq edit_registration_url(registration)
           # Check that the website actually records who made the charge
           expect(registration.registration_payments.first.user).to eq user
         end
@@ -556,7 +555,7 @@ RSpec.describe "registrations" do
           stripe_charge = StripeCharge.find_by(stripe_charge_id: stripe_charge_id)
           expect(stripe_charge&.status).to eq "success"
           metadata = JSON.parse(stripe_charge.metadata)["metadata"]
-          expect(metadata["wca_id"]).to eq registration.user.wca_id
+          expect(metadata["competition"]).to eq competition.name
         end
       end
 
@@ -597,7 +596,7 @@ RSpec.describe "registrations" do
           expect(stripe_charge&.status).to eq "payment_intent_registered"
           metadata = JSON.parse(stripe_charge.metadata)
           expect(metadata["payment_method"]).to eq pm.id
-          expect(metadata["metadata"]["wca_id"]).to eq registration.user.wca_id
+          expect(metadata["metadata"]["competition"]).to eq competition.name
         end
       end
 
@@ -660,7 +659,7 @@ RSpec.describe "registrations" do
           expect(stripe_charge&.status).to eq "failure"
           metadata = JSON.parse(stripe_charge.metadata)
           expect(metadata["payment_method"]).to eq pm.id
-          expect(metadata["metadata"]["wca_id"]).to eq registration.user.wca_id
+          expect(metadata["metadata"]["competition"]).to eq competition.name
         end
       end
     end


### PR DESCRIPTION
[Stripe documentation](https://stripe.com/docs/payments/payment-intents#storing-information-in-metadata) warns to not store sensitive information in the description or metadata of the PaymentIntent. This PR is intended to remove it.

This PR is intended to remove the PII from the metadata and description. At a later stage some of the information in the metadata could still be sent through to stripe using the [customer or shipping attributes](https://stripe.com/docs/api/payment_intents/object). Cardholder name and receipt email (equal to user email) are still stored by stripe and are accessible through the dashboard. 